### PR TITLE
Email and Credentials based login is available based on ENV variables

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -3,9 +3,14 @@ NEXTAUTH_URL=http://localhost:3001/
 NEXTAUTH_SECRET= # Linux: `openssl rand -hex 32` or go to https://generate-secret.vercel.app/32
 
 # Providers
+ENABLE_CREDENTIALS_PROVIDER=true
 ENABLE_EMAIL_PROVIDER=false
 ENABLE_GITHUB_PROVIDER=false
 ENABLE_GOOGLE_PROVIDER=false
+
+# Credentials Provider Parameters
+CREDENTIALS_APPROVED_USERNAME=jsmith
+CREDENTIALS_APPROVED_PASSWORD=localhost@
 
 # Email Server Parameters
 EMAIL_SERVER_USER=resend

--- a/.env.template
+++ b/.env.template
@@ -2,9 +2,23 @@
 NEXTAUTH_URL=http://localhost:3001/
 NEXTAUTH_SECRET= # Linux: `openssl rand -hex 32` or go to https://generate-secret.vercel.app/32
 
+# Providers
+ENABLE_EMAIL_PROVIDER=false
+ENABLE_GITHUB_PROVIDER=false
+ENABLE_GOOGLE_PROVIDER=false
+
+# Email Server Parameters
+EMAIL_SERVER_USER=resend
+EMAIL_SERVER_PASSWORD=
+EMAIL_SERVER_HOST=smtp.resend.com
+EMAIL_SERVER_PORT=465
+EMAIL_FROM=no-reply@assistantshub.ai
+
+# GitHub OAuth Parameters
 GITHUB_CLIENT_ID=
 GITHUB_CLIENT_SECRET=
 
+# Google OAuth Parameters
 GOOGLE_CLIENT_ID=
 GOOGLE_CLIENT_SECRET=
 

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ To get started with Assistants Hub, you'll need to have Node.js installed on you
 
 Visit http://localhost:3001 in your browser to see your AI assistant in action.
 
+7. Logging into your local instance.
+   - By default the local instance is configured to use Credentials based authentication. 
+   - You can login using CREDENTIALS_APPROVED_USERNAME and CREDENTIALS_APPROVED_PASSWORD in your .env file.
+
 ## Contributing
 
 Your contributions can help make Assistants Hub even better. If you're interested in contributing, please read our [CONTRIBUTING.md](./CONTRIBUTING.md) file to learn how you can get involved.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "marked-react": "^2.0.0",
     "next": "14.0.4",
     "next-auth": "^4.24.5",
+    "nodemailer": "^6.9.13",
     "openai": "^4.32.0",
     "react": "^18",
     "react-apexcharts": "^1.4.1",
@@ -46,6 +47,7 @@
   },
   "devDependencies": {
     "@types/node": "^20",
+    "@types/nodemailer": "^6.4.14",
     "@types/react": "^18",
     "@types/react-dom": "^18",
     "@typescript-eslint/parser": "^6.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 dependencies:
   '@auth/prisma-adapter':
     specifier: ^2.0.0
-    version: 2.0.0(@prisma/client@5.8.1)
+    version: 2.0.0(@prisma/client@5.8.1)(nodemailer@6.9.13)
   '@google/generative-ai':
     specifier: ^0.8.0
     version: 0.8.0
@@ -49,7 +49,10 @@ dependencies:
     version: 14.0.4(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
   next-auth:
     specifier: ^4.24.5
-    version: 4.24.5(next@14.0.4)(react-dom@18.2.0)(react@18.2.0)
+    version: 4.24.5(next@14.0.4)(nodemailer@6.9.13)(react-dom@18.2.0)(react@18.2.0)
+  nodemailer:
+    specifier: ^6.9.13
+    version: 6.9.13
   openai:
     specifier: ^4.32.0
     version: 4.32.0
@@ -94,6 +97,9 @@ devDependencies:
   '@types/node':
     specifier: ^20
     version: 20.10.8
+  '@types/nodemailer':
+    specifier: ^6.4.14
+    version: 6.4.14
   '@types/react':
     specifier: ^18
     version: 18.2.47
@@ -150,7 +156,7 @@ packages:
       }
     engines: { node: '>=10' }
 
-  /@auth/core@0.30.0:
+  /@auth/core@0.30.0(nodemailer@6.9.13):
     resolution:
       {
         integrity: sha512-8AE4m/nk+4EIiVCJwxZAsJeAQuzpEC8M8768mmKVn60CGDdupKQkVhxbRlm5Qh7eNRCoFFME+0DvtaX2aXrYaA==,
@@ -171,12 +177,13 @@ packages:
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       jose: 5.2.4
+      nodemailer: 6.9.13
       oauth4webapi: 2.10.4
       preact: 10.11.3
       preact-render-to-string: 5.2.3(preact@10.11.3)
     dev: false
 
-  /@auth/prisma-adapter@2.0.0(@prisma/client@5.8.1):
+  /@auth/prisma-adapter@2.0.0(@prisma/client@5.8.1)(nodemailer@6.9.13):
     resolution:
       {
         integrity: sha512-ZBH9mXBIeWNRl/HOWd+nnxZym42wQPsIeC69jlkShpEAYt1tB+ubwL13EdfG2GRueOG3+rkWOSHaDajyKdWe9w==,
@@ -184,7 +191,7 @@ packages:
     peerDependencies:
       '@prisma/client': '>=2.26.0 || >=3 || >=4 || >=5'
     dependencies:
-      '@auth/core': 0.30.0
+      '@auth/core': 0.30.0(nodemailer@6.9.13)
       '@prisma/client': 5.8.1(prisma@5.8.1)
     transitivePeerDependencies:
       - '@simplewebauthn/browser'
@@ -1760,6 +1767,15 @@ packages:
       }
     dependencies:
       undici-types: 5.26.5
+
+  /@types/nodemailer@6.4.14:
+    resolution:
+      {
+        integrity: sha512-fUWthHO9k9DSdPCSPRqcu6TWhYyxTBg382vlNIttSe9M7XfsT06y0f24KHXtbnijPGGRIcVvdKHTNikOI6qiHA==,
+      }
+    dependencies:
+      '@types/node': 20.10.8
+    dev: true
 
   /@types/parse5@6.0.3:
     resolution:
@@ -6436,7 +6452,7 @@ packages:
       }
     dev: true
 
-  /next-auth@4.24.5(next@14.0.4)(react-dom@18.2.0)(react@18.2.0):
+  /next-auth@4.24.5(next@14.0.4)(nodemailer@6.9.13)(react-dom@18.2.0)(react@18.2.0):
     resolution:
       {
         integrity: sha512-3RafV3XbfIKk6rF6GlLE4/KxjTcuMCifqrmD+98ejFq73SRoj2rmzoca8u764977lH/Q7jo6Xu6yM+Re1Mz/Og==,
@@ -6455,6 +6471,7 @@ packages:
       cookie: 0.5.0
       jose: 4.15.4
       next: 14.0.4(@opentelemetry/api@1.7.0)(react-dom@18.2.0)(react@18.2.0)
+      nodemailer: 6.9.13
       oauth: 0.9.15
       openid-client: 5.6.4
       preact: 10.19.3
@@ -6600,6 +6617,14 @@ packages:
         integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==,
       }
     dev: true
+
+  /nodemailer@6.9.13:
+    resolution:
+      {
+        integrity: sha512-7o38Yogx6krdoBf3jCAqnIN4oSQFx+fMa0I7dK1D+me9kBxx12D+/33wSb+fhOCtIxvYJ+4x4IMEhmhCKfAiOA==,
+      }
+    engines: { node: '>=6.0.0' }
+    dev: false
 
   /normalize-path@3.0.0:
     resolution:

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -4,46 +4,69 @@ import GoogleProvider from 'next-auth/providers/google';
 import { PrismaAdapter } from '@auth/prisma-adapter';
 import { PrismaClient } from '@prisma/client';
 import EmailProvider from 'next-auth/providers/email';
+import CredentialsProvider from "next-auth/providers/credentials"
 import { sendVerificationRequest } from '@/app/api/utils';
 
 const prisma = new PrismaClient();
 
-const emailProvider = EmailProvider({
-  server: {
-    host: process.env.EMAIL_SERVER_HOST,
-    port: process.env.EMAIL_SERVER_PORT,
-    auth: {
-      user: process.env.EMAIL_SERVER_USER,
-      pass: process.env.EMAIL_SERVER_PASSWORD,
-    },
-  },
-  from: process.env.EMAIL_FROM,
-  sendVerificationRequest: sendVerificationRequest,
-});
-
-const googleProvider = GoogleProvider({
-  clientId: process.env.GOOGLE_CLIENT_ID ? process.env.GOOGLE_CLIENT_ID : '',
-  clientSecret: process.env.GOOGLE_CLIENT_SECRET
-    ? process.env.GOOGLE_CLIENT_SECRET
-    : '',
-});
-
-const githubProvider = GitHub({
-  clientId: process.env.GITHUB_CLIENT_ID ? process.env.GITHUB_CLIENT_ID : '',
-  clientSecret: process.env.GITHUB_CLIENT_SECRET
-    ? process.env.GITHUB_CLIENT_SECRET
-    : '',
-});
-
 let providers = [];
 
+if (process.env.ENABLE_CREDENTIALS_PROVIDER === 'true') {
+  // NOTE: This is intended for localhost testing or integrating with actual internal systems
+  // NOTE: Documentation for this provider can be found here: https://next-auth.js.org/providers/credentials
+  // WARNING: This is not recommended for production use, without proper modifications
+  let credentialsProvider = {
+    id: 'credentials',
+    name: 'Credentials',
+    credentials: {
+      username: { label: 'Username', type: 'text' },
+      password: { label: 'Password', type: 'password' },
+    },
+    async authorize(credentials:any) {
+      if(credentials.username === process.env.CREDENTIALS_APPROVED_USERNAME && credentials.password === process.env.CREDENTIALS_APPROVED_PASSWORD) {
+        return { id: 1, name: 'J Smith', email: process.env.CREDENTIALS_APPROVED_USERNAME + '@assistantshub.ai' };
+      }
+      return null;
+    }
+  }
+
+  providers.push(CredentialsProvider(credentialsProvider as any));
+}
+
 if (process.env.ENABLE_EMAIL_PROVIDER === 'true') {
+  const emailProvider = EmailProvider({
+    server: {
+      host: process.env.EMAIL_SERVER_HOST,
+      port: process.env.EMAIL_SERVER_PORT,
+      auth: {
+        user: process.env.EMAIL_SERVER_USER,
+        pass: process.env.EMAIL_SERVER_PASSWORD,
+      },
+    },
+    from: process.env.EMAIL_FROM,
+    sendVerificationRequest: sendVerificationRequest,
+  });
+
   providers.push(emailProvider);
 }
 if (process.env.ENABLE_GITHUB_PROVIDER === 'true') {
+  const githubProvider = GitHub({
+    clientId: process.env.GITHUB_CLIENT_ID ? process.env.GITHUB_CLIENT_ID : '',
+    clientSecret: process.env.GITHUB_CLIENT_SECRET
+      ? process.env.GITHUB_CLIENT_SECRET
+      : '',
+  });
+
   providers.push(githubProvider);
 }
 if (process.env.ENABLE_GOOGLE_PROVIDER === 'true') {
+  const googleProvider = GoogleProvider({
+    clientId: process.env.GOOGLE_CLIENT_ID ? process.env.GOOGLE_CLIENT_ID : '',
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET
+      ? process.env.GOOGLE_CLIENT_SECRET
+      : '',
+  });
+
   providers.push(googleProvider);
 }
 

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -3,29 +3,53 @@ import GitHub from 'next-auth/providers/github';
 import GoogleProvider from 'next-auth/providers/google';
 import { PrismaAdapter } from '@auth/prisma-adapter';
 import { PrismaClient } from '@prisma/client';
+import EmailProvider from 'next-auth/providers/email';
+import { sendVerificationRequest } from '@/app/api/utils';
 
 const prisma = new PrismaClient();
 
+const emailProvider = EmailProvider({
+  server: {
+    host: process.env.EMAIL_SERVER_HOST,
+    port: process.env.EMAIL_SERVER_PORT,
+    auth: {
+      user: process.env.EMAIL_SERVER_USER,
+      pass: process.env.EMAIL_SERVER_PASSWORD,
+    },
+  },
+  from: process.env.EMAIL_FROM,
+  sendVerificationRequest: sendVerificationRequest,
+});
+
+const googleProvider = GoogleProvider({
+  clientId: process.env.GOOGLE_CLIENT_ID ? process.env.GOOGLE_CLIENT_ID : '',
+  clientSecret: process.env.GOOGLE_CLIENT_SECRET
+    ? process.env.GOOGLE_CLIENT_SECRET
+    : '',
+});
+
+const githubProvider = GitHub({
+  clientId: process.env.GITHUB_CLIENT_ID ? process.env.GITHUB_CLIENT_ID : '',
+  clientSecret: process.env.GITHUB_CLIENT_SECRET
+    ? process.env.GITHUB_CLIENT_SECRET
+    : '',
+});
+
+let providers = [];
+
+if (process.env.ENABLE_EMAIL_PROVIDER === 'true') {
+  providers.push(emailProvider);
+}
+if (process.env.ENABLE_GITHUB_PROVIDER === 'true') {
+  providers.push(githubProvider);
+}
+if (process.env.ENABLE_GOOGLE_PROVIDER === 'true') {
+  providers.push(googleProvider);
+}
+
 export const authOptions = {
   adapter: PrismaAdapter(prisma),
-  providers: [
-    GoogleProvider({
-      clientId: process.env.GOOGLE_CLIENT_ID
-        ? process.env.GOOGLE_CLIENT_ID
-        : '',
-      clientSecret: process.env.GOOGLE_CLIENT_SECRET
-        ? process.env.GOOGLE_CLIENT_SECRET
-        : '',
-    }),
-    GitHub({
-      clientId: process.env.GITHUB_CLIENT_ID
-        ? process.env.GITHUB_CLIENT_ID
-        : '',
-      clientSecret: process.env.GITHUB_CLIENT_SECRET
-        ? process.env.GITHUB_CLIENT_SECRET
-        : '',
-    }),
-  ],
+  providers: providers,
   secret: process.env.NEXTAUTH_SECRET,
   theme: {
     colorScheme: 'auto', // "auto" | "dark" | "light"

--- a/src/app/api/google/threads/[id]/runs/route.ts
+++ b/src/app/api/google/threads/[id]/runs/route.ts
@@ -27,7 +27,7 @@ const getLatestMessage = async (threadId: string) => {
 
   // @ts-ignore
   return messages[0]?.object?.content[0]?.text?.value;
-}
+};
 
 const formatChatParams = async (threadId: string) => {
   let messages = await prisma.message.findMany({
@@ -44,7 +44,8 @@ const formatChatParams = async (threadId: string) => {
 
   let history = [];
   let previousRole = null;
-  for (let i = 0; i < messages.length - 1; i++) { // -1 to exclude the last message
+  for (let i = 0; i < messages.length - 1; i++) {
+    // -1 to exclude the last message
 
     let item = messages[i];
     // @ts-ignore
@@ -133,7 +134,8 @@ export async function POST(req: NextRequest, res: NextResponse) {
     let chatParams = await formatChatParams(threadId);
     const chat = genAIModel.startChat(chatParams);
     let message = await getLatestMessage(threadId);
-    const runResponse: GenerateContentStreamResult = await chat.sendMessageStream(message);
+    const runResponse: GenerateContentStreamResult =
+      await chat.sendMessageStream(message);
 
     let msgId = 'msg_' + ulid();
 

--- a/src/app/api/utils.ts
+++ b/src/app/api/utils.ts
@@ -1,6 +1,8 @@
 import { NextRequest } from 'next/server';
 import OpenAI from 'openai';
 import { PrismaClient } from '@prisma/client';
+import { createTransport } from 'nodemailer';
+import { Theme } from 'next-auth';
 
 const { GoogleGenerativeAI } = require('@google/generative-ai');
 
@@ -43,7 +45,7 @@ export const getGoogleGenAIObjectForAssistant = async (
     select: {
       organization: true,
       modelId: true,
-      object: true
+      object: true,
     },
   });
 
@@ -59,6 +61,102 @@ export const getGoogleGenAIObjectForAssistant = async (
     systemInstruction: {
       role: 'model',
       // @ts-ignore
-      parts: [{ text: assistant?.object?.instructions }]
-    }});
+      parts: [{ text: assistant?.object?.instructions }],
+    },
+  });
 };
+
+/**
+ * Email HTML body
+ * Insert invisible space into domains from being turned into a hyperlink by email
+ * clients like Outlook and Apple mail, as this is confusing because it seems
+ * like they are supposed to click on it to sign in.
+ *
+ * @note We don't add the email address to avoid needing to escape it, if you do, remember to sanitize it!
+ */
+function html(params: { url: string; host: string; theme: Theme }) {
+  const { url, host, theme } = params;
+
+  const escapedHost = host.replace(/\./g, '&#8203;.');
+  const currentYear = new Date().getFullYear(); // Get the current year dynamically
+
+  const brandColor = theme.brandColor || '#346df1';
+  const color = {
+    background: '#f9f9f9',
+    text: '#444',
+    mainBackground: '#fff',
+    buttonBackground: brandColor,
+    buttonBorder: brandColor,
+    buttonText: theme.buttonText || '#fff',
+  };
+
+  return `
+<body style="background: ${color.background}; font-family: Arial, sans-serif; margin: 20px;">
+  <table width="100%" border="0" cellspacing="20" cellpadding="0" style="background: ${color.mainBackground}; max-width: 600px; margin: auto; border-radius: 10px;">
+    <tr>
+      <td align="center" style="padding: 20px;">
+        <img src="https://www.assistantshub.ai/logo.png" alt="${escapedHost} Logo" style="width: 100px; margin-bottom: 20px;">
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding: 10px 0px; font-size: 22px; color: ${color.text};">
+        Welcome to <strong>${escapedHost}</strong>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding: 20px 0;">
+        <table border="0" cellspacing="0" cellpadding="0">
+          <tr>
+            <td align="center" style="border-radius: 5px;" bgcolor="${color.buttonBackground}">
+              <a href="${url}" target="_blank" style="font-size: 18px; color: ${color.buttonText}; text-decoration: none; border-radius: 5px; padding: 10px 20px; border:${color.buttonBorder} 1px solid; display: inline-block; font-weight: bold;">Sign in Now</a>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="padding: 0px 0px 10px; font-size: 16px; line-height: 22px; color: ${color.text};">
+        If you did not request this sign-in link, please ignore this email or contact support if you have concerns.
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="font-size: 12px; color: #777;">
+        Visit our website for more information: <a href="https://assistantsHub.ai" style="text-decoration: none; color: ${brandColor};">assistantshub.ai</a>. Thank you!
+      </td>
+    </tr>
+    <tr>
+      <td align="center" style="font-size: 12px; color: #777;">
+        <small>&copy; ${currentYear} AssistantsHub.ai</small>
+      </td>
+    </tr>
+  </table>
+</body>
+`;
+}
+
+/** Email Text body (fallback for email clients that don't render HTML, e.g. feature phones) */
+function text({ url, host }: { url: string; host: string }) {
+  return `Sign in to ${host}\n${url}\n\n`;
+}
+
+export async function sendVerificationRequest({
+  identifier,
+  url,
+  provider,
+  theme,
+}: any) {
+  const { host } = new URL(url);
+  // NOTE: You are not required to use `nodemailer`, use whatever you want.
+  const transport = createTransport(provider.server);
+  const result = await transport.sendMail({
+    to: identifier,
+    from: provider.from,
+    subject: `Sign in to ${host}`,
+    text: text({ url, host }),
+    html: html({ url, host, theme }),
+  });
+  const failed = result.rejected.concat(result.pending).filter(Boolean);
+  if (failed.length) {
+    throw new Error(`Email(s) (${failed.join(', ')}) could not be sent`);
+  }
+}


### PR DESCRIPTION
You can now use the following variables in `.env` appropriately enable or disable the authentication mechanism. Below is the one recommended for local environments 

```
ENABLE_CREDENTIALS_PROVIDER=true
ENABLE_EMAIL_PROVIDER=false
ENABLE_GITHUB_PROVIDER=false
ENABLE_GOOGLE_PROVIDER=false
```
When enabled will use the `CREDENTIALS_APPROVED_USERNAME ` and `CREDENTIALS_APPROVED_PASSWORD ` to authenticate the user locally. Below is the one recommended for production environments

```
ENABLE_CREDENTIALS_PROVIDER=false
ENABLE_EMAIL_PROVIDER=true
ENABLE_GITHUB_PROVIDER=true
ENABLE_GOOGLE_PROVIDER=true
```